### PR TITLE
Refactor imports and add location type for external apps

### DIFF
--- a/src/scripts/application/ExternalApp.ts
+++ b/src/scripts/application/ExternalApp.ts
@@ -1,21 +1,20 @@
-import {
-  EFirestoreDocumentType,
-  IFirestoreDocumentData,
-} from 'src/scripts/application/FirestoreDocument';
+import * as fd from 'src/scripts/application/FirestoreDocument';
+import * as pc from 'src/scripts/provider/common';
 import { ProjectDocument } from 'src/scripts/application/ProjectDocument';
 import { loadChildDocuments, Project } from 'src/scripts/application/Project';
-import { TProviderCredentials } from 'src/scripts/provider/common';
 import { TCustomAttribute } from 'src/scripts/utilities/common';
 import { EExternalAppProvider } from 'src/scripts/provider/common';
 
 /**
  * Represents the external application data associated with a provider.
  */
-export interface IExternalAppData extends IFirestoreDocumentData {
+export interface IExternalAppData extends fd.IFirestoreDocumentData {
+  /** Location Type */
+  locationType: pc.ELocationType;
   /** Provider */
   provider: EExternalAppProvider;
   /** Credentials */
-  credentials: TProviderCredentials;
+  credentials: pc.TProviderCredentials;
   /** Custom Attributes */
   attributes: TCustomAttribute[];
 }
@@ -33,7 +32,7 @@ export class ExternalApp extends ProjectDocument<IExternalAppData> {}
 export async function loadExternalApps(project: Project): Promise<void> {
   await loadChildDocuments(
     project,
-    EFirestoreDocumentType.ExternalApp,
+    fd.EFirestoreDocumentType.ExternalApp,
     (document) => new ExternalApp({ obj: document }, project)
   );
 }

--- a/src/scripts/provider/common.ts
+++ b/src/scripts/provider/common.ts
@@ -12,6 +12,25 @@ export enum EExternalAppProvider {
 }
 
 /**
+ * Enum representing different types of location sources.
+ *
+ * This enum is used to specify the type of location being referenced or utilized.
+ *
+ * Enum Members:
+ *   - `file`: Represents a file storage location. This can be used in contexts where
+ *     file-based storage systems are accessed or manipulated.
+ *
+ *   - `relational`: Represents a relational data location. Commonly used in contexts
+ *     involving access or management of relational databases.
+ */
+export enum ELocationType {
+  /** File Storage Location */
+  file = 'file',
+  /** Relational Data Location */
+  relational = 'relational',
+}
+
+/**
  * Type definition for provider credentials.
  */
 export type TProviderCredentials =

--- a/src/scripts/ui/externalApp.ts
+++ b/src/scripts/ui/externalApp.ts
@@ -1,9 +1,8 @@
 import { EditorData } from 'src/scripts/ui/common';
 import { IExternalAppData } from 'src/scripts/application/ExternalApp';
 import { FirestoreDocument } from 'src/scripts/application/FirestoreDocument';
-import { TProviderCredentials } from 'src/scripts/provider/common';
 import { TCustomAttribute } from 'src/scripts/utilities/common';
-import { EExternalAppProvider } from 'src/scripts/provider/common';
+import * as pc from 'src/scripts/provider/common';
 import * as s3 from 'src/scripts/provider/s3';
 import * as snflk from 'src/scripts/provider/snowflake';
 
@@ -14,10 +13,10 @@ import * as snflk from 'src/scripts/provider/snowflake';
  */
 export class EditorExternalAppData extends EditorData<IExternalAppData> {
   /** Provider */
-  provider: EExternalAppProvider;
+  provider: pc.EExternalAppProvider;
 
   /** Credentials */
-  credentials: TProviderCredentials;
+  credentials: pc.TProviderCredentials;
 
   /** Custom Attributes */
   attributes: TCustomAttribute[];
@@ -27,7 +26,7 @@ export class EditorExternalAppData extends EditorData<IExternalAppData> {
    */
   constructor() {
     super();
-    this.provider = EExternalAppProvider.S3;
+    this.provider = pc.EExternalAppProvider.S3;
     this.credentials = {
       region: 'us-east-1',
       bucket: '',
@@ -45,13 +44,16 @@ export class EditorExternalAppData extends EditorData<IExternalAppData> {
    */
   createData(): IExternalAppData {
     // Create credentials object
-    let credentials: TProviderCredentials = {};
-    if (this.provider === EExternalAppProvider.S3) {
+    let credentials:pc. TProviderCredentials = {};
+    let locationType: pc.ELocationType = pc.ELocationType.file;
+    if (this.provider === pc.EExternalAppProvider.S3) {
       // Amazon S3 credentials
       credentials = s3.createCredentials(this.credentials);
-    } else if (this.provider == EExternalAppProvider.Snowflake) {
+      locationType = pc.ELocationType.file;
+    } else if (this.provider == pc.EExternalAppProvider.Snowflake) {
       // Snowflake credentials
       credentials = snflk.createCredentials(this.credentials);
+      locationType = pc.ELocationType.relational;
     }
     // Return data object
     return {
@@ -59,6 +61,7 @@ export class EditorExternalAppData extends EditorData<IExternalAppData> {
         name: this.name,
         description: this.description,
       },
+      locationType: locationType,
       provider: this.provider,
       credentials: credentials,
       attributes: this.attributes,


### PR DESCRIPTION
Consolidate imports using namespace imports for better organization and readability. Introduce `ELocationType` enum to specify the type of location for external applications, allowing differentiation between file and relational storage types. Adjust code to accommodate the new location type attribute in `IExternalAppData`.